### PR TITLE
Add declarative NGF client plugin

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -1,0 +1,23 @@
+TARGET = libngf-declarative
+PLUGIN_IMPORT_PATH = org/nemomobile/ngf
+
+LIBS += -L../src/ \
+    -lngf-qt
+
+INCLUDEPATH += ../src/include
+
+SOURCES += src/plugin.cpp \
+    src/declarativengfevent.cpp
+
+HEADERS += src/declarativengfevent.h
+
+TEMPLATE = lib
+CONFIG += qt plugin hide_symbols
+QT += declarative
+
+target.path = $$[QT_INSTALL_IMPORTS]/$$PLUGIN_IMPORT_PATH
+INSTALLS += target
+
+qmldir.files += $$PWD/qmldir
+qmldir.path +=  $$[QT_INSTALL_IMPORTS]/$$$$PLUGIN_IMPORT_PATH
+INSTALLS += qmldir

--- a/declarative/qmldir
+++ b/declarative/qmldir
@@ -1,0 +1,1 @@
+plugin libngf-declarative

--- a/declarative/src/declarativengfevent.cpp
+++ b/declarative/src/declarativengfevent.cpp
@@ -1,0 +1,162 @@
+/* Copyright (C) 2013 Jolla Ltd.
+ * Contact: John Brooks <john.brooks@jollamobile.com>
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "declarativengfevent.h"
+#include <NgfClient>
+
+static QSharedPointer<Ngf::Client> clientInstance()
+{
+    static QWeakPointer<Ngf::Client> client;
+
+    QSharedPointer<Ngf::Client> re = client.toStrongRef();
+    if (re.isNull()) {
+        re = QSharedPointer<Ngf::Client>(new Ngf::Client);
+        client = re.toWeakRef();
+    }
+
+    return re;
+}
+
+DeclarativeNgfEvent::DeclarativeNgfEvent(QObject *parent)
+    : QObject(parent), client(clientInstance()), m_status(Stopped), m_eventId(0), m_autostart(false)
+{
+    connect(client.data(), SIGNAL(connectionStatus(bool)), SLOT(connectionStatusChanged(bool)));
+    connect(client.data(), SIGNAL(eventFailed(quint32)), SLOT(eventFailed(quint32)));
+    connect(client.data(), SIGNAL(eventCompleted(quint32)), SLOT(eventCompleted(quint32)));
+    connect(client.data(), SIGNAL(eventPlaying(quint32)), SLOT(eventPlaying(quint32)));
+    connect(client.data(), SIGNAL(eventPaused(quint32)), SLOT(eventPaused(quint32)));
+}
+
+DeclarativeNgfEvent::~DeclarativeNgfEvent()
+{
+    stop();
+}
+
+void DeclarativeNgfEvent::setEvent(const QString &event)
+{
+    if (m_event == event)
+        return;
+
+    if (m_eventId) {
+        stop();
+        m_autostart = true;
+    }
+
+    m_event = event;
+
+    emit eventChanged();
+    if (m_autostart)
+        play();
+}
+
+void DeclarativeNgfEvent::play()
+{
+    if (!isConnected())
+        client->connect();
+
+    m_autostart = true;
+
+    if (m_eventId)
+        stop();
+
+    if (!m_event.isEmpty() && isConnected())
+        m_eventId = client->play(m_event);
+}
+
+void DeclarativeNgfEvent::pause()
+{
+    if (!m_eventId)
+        return;
+
+    client->pause(m_eventId);
+}
+
+void DeclarativeNgfEvent::resume()
+{
+    if (!m_eventId)
+        return;
+
+    client->resume(m_eventId);
+}
+
+void DeclarativeNgfEvent::stop()
+{
+    m_autostart = false;
+
+    if (!m_eventId)
+        return;
+
+    client->stop(m_eventId);
+    m_eventId = 0;
+    m_status = Stopped;
+    emit statusChanged();
+}
+
+bool DeclarativeNgfEvent::isConnected() const
+{
+    return client->isConnected();
+}
+
+void DeclarativeNgfEvent::connectionStatusChanged(bool connected)
+{
+    if (connected && m_autostart) {
+        m_autostart = false;
+        play();
+    }
+
+    emit connectedChanged();
+}
+
+void DeclarativeNgfEvent::eventFailed(quint32 id)
+{
+    if (id != m_eventId)
+        return;
+
+    m_eventId = 0;
+    m_status = Failed;
+    emit statusChanged();
+}
+
+void DeclarativeNgfEvent::eventCompleted(quint32 id)
+{
+    if (id != m_eventId)
+        return;
+
+    m_eventId = 0;
+    m_status = Stopped;
+    emit statusChanged();
+}
+
+void DeclarativeNgfEvent::eventPlaying(quint32 id)
+{
+    if (id != m_eventId)
+        return;
+
+    m_status = Playing;
+    m_autostart = false;
+    emit statusChanged();
+}
+
+void DeclarativeNgfEvent::eventPaused(quint32 id)
+{
+    if (id != m_eventId)
+        return;
+
+    m_status = Paused;
+    emit statusChanged();
+}
+

--- a/declarative/src/declarativengfevent.h
+++ b/declarative/src/declarativengfevent.h
@@ -1,0 +1,150 @@
+/* Copyright (C) 2013 Jolla Ltd.
+ * Contact: John Brooks <john.brooks@jollamobile.com>
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef DECLARATIVENGFEVENT_H
+#define DECLARATIVENGFEVENT_H
+
+#include <QObject>
+#include <QSharedPointer>
+
+namespace Ngf {
+    class Client;
+}
+
+/*!
+   \qmlclass NonGraphicalFeedback DeclarativeNgfEvent
+   \brief Playback of non-graphical feedback events
+ 
+   NonGraphicalFeedback allows playback of system-defined events via the ngf
+   daemon, such as notification sounds and effects.
+ 
+   An event's actions are defined by a string which is mapped to configuration
+   files installed on the system. Examples include "ringtone", "chat", or "battery_low".
+ 
+   \qml
+   NonGraphicalFeedback {
+       id: ringtone
+       event: "ringtone"
+
+       Connections {
+           target: phone
+           onIncomingCall: ringtone.play()
+           onCallAnswered: ringtone.stop()
+       }
+   }
+   \endqml
+ */
+
+class DeclarativeNgfEvent : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(EventStatus)
+
+public:
+    enum EventStatus {
+        Stopped,
+        Failed,
+        Playing,
+        Paused
+    };
+
+    DeclarativeNgfEvent(QObject *parent = 0);
+    virtual ~DeclarativeNgfEvent();
+
+    /*!
+       \qmlproperty bool connected
+
+       Indicates if the NGF daemon is connected and active. The connection
+       will be established automatically when needed.
+     */
+    Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged)
+    bool isConnected() const;
+
+    /*!
+       \qmlproperty string event
+
+       Set the NGF event name. Events are defined in system-installed configuration files
+       with a short name like "ringtone" or "battery_low".
+
+       If the event is changed while playing, playback will be restarted
+       automatically with the new event.
+     */
+    Q_PROPERTY(QString event READ event WRITE setEvent NOTIFY eventChanged)
+    QString event() const { return m_event; }
+    void setEvent(const QString &event);
+
+    /*!
+       \qmlproperty EventStatus status
+
+       Current status of playback. This property is updated asynchronously after
+       requests to play, pause, or stop the event.
+     */
+    Q_PROPERTY(EventStatus status READ status NOTIFY statusChanged)
+    EventStatus status() const { return m_status; }
+
+public slots:
+    /*!
+       \qmlmethod void NonGraphicalFeedback::play()
+
+       Begins playing the defined event. If already playing, playback will be
+       restarted from the beginning.
+
+       Actual playback happens asynchronously. The \c status property will change
+       when playback begins and ends, or in case of failure.
+     */
+    void play();
+    /*!
+       \qmlmethod void NonGraphicalFeedback::pause()
+
+       Pause the currently playing event. Playback can be resumed with \a resume()
+     */
+    void pause();
+    /*!
+       \qmlmethod void NonGraphicalFeedback::resume()
+
+       Resume a paused event.
+     */
+    void resume();
+    /*!
+       \qmlmethod void NonGraphicalFeedback::stop()
+
+       Stop playback of the event.
+     */
+    void stop();
+
+signals:
+    void connectedChanged();
+    void eventChanged();
+    void statusChanged();
+
+private slots:
+    void connectionStatusChanged(bool connected);
+    void eventFailed(quint32 id);
+    void eventCompleted(quint32 id);
+    void eventPlaying(quint32 id);
+    void eventPaused(quint32 id);
+
+private:
+    QSharedPointer<Ngf::Client> client;
+    QString m_event;
+    EventStatus m_status;
+    quint32 m_eventId;
+    bool m_autostart;
+};
+
+#endif
+

--- a/declarative/src/plugin.cpp
+++ b/declarative/src/plugin.cpp
@@ -1,0 +1,45 @@
+/* Copyright (C) 2013 Jolla Ltd.
+ * Contact: John Brooks <john.brooks@jollamobile.com>
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <QtGlobal>
+#include <QtDeclarative>
+#include <QDeclarativeEngine>
+#include <QDeclarativeExtensionPlugin>
+#include "declarativengfevent.h"
+
+class Q_DECL_EXPORT NgfPlugin : public QDeclarativeExtensionPlugin
+{
+public:
+    virtual ~NgfPlugin() { }
+
+    void initializeEngine(QDeclarativeEngine *engine, const char *uri)
+    {
+        Q_ASSERT(uri == QLatin1String("org.nemomobile.ngf"));
+        Q_UNUSED(uri);
+        Q_UNUSED(engine);
+    }
+
+    void registerTypes(const char *uri)
+    {
+        Q_ASSERT(uri == QLatin1String("org.nemomobile.ngf"));
+
+        qmlRegisterType<DeclarativeNgfEvent>(uri, 1, 0, "NonGraphicalFeedback");
+    }
+};
+
+Q_EXPORT_PLUGIN2(ngfplugin, NgfPlugin);
+

--- a/project.pro
+++ b/project.pro
@@ -3,7 +3,7 @@ isEmpty(PREFIX) {
     PREFIX = /usr/local
 }
 TEMPLATE = subdirs
-SUBDIRS += src
+SUBDIRS += src declarative
 
 # No need to build this, but if you want then 'qmake EXAMPLE=1 && make'
 count(EXAMPLE, 1) {


### PR DESCRIPTION
This plugin provides org.nemomobile.ngf to QML. The NonGraphicalFeedback element allows playing NGF events with the full flexibility of the Qt API. Currently, it is not possible to set parameters for an event.

No proper documentation yet, and no tests yet as libngf-qt doesn't have them either - and it may be complicated due to the daemon's involvement.
